### PR TITLE
bguides/http/simple: fix output of port number in log

### DIFF
--- a/docs/guides/http/simple.md
+++ b/docs/guides/http/simple.md
@@ -14,5 +14,5 @@ const server = Bun.serve({
   },
 });
 
-console.log(`Listening on localhost:\${server.port}`);
+console.log(`Listening on localhost:${server.port}`);
 ```


### PR DESCRIPTION
### What does this PR do?

The documented code was was not outputting the port number before.

- [x] Documentation or TypeScript types (it's okay to leave the rest blank in this case)
- [ ] Code changes

### How did you verify your code works?

I ran the updated code with Bun and it output the port to console.
